### PR TITLE
Adding Android Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  android:
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        machine: [arm, arm64]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: ls -l /usr/local/lib/android/sdk/ndk-bundle
+      - run: sudo ./script/prepare_linux.sh
+      - run: python3 script/check_release.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
+      - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/build.py --system android --machine ${{ matrix.machine }} --ndk "/usr/local/lib/android/sdk/ndk-bundle"
+      - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/archive.py --system android --machine ${{ matrix.machine }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Skia-${{ env.version }}-android-Release-${{ matrix.machine }}.zip
+          path: '*.zip'
+      - run: python3 script/release.py --system android --machine ${{ matrix.machine }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   windows:
     runs-on: windows-2019
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,14 @@ on:
       - "script/*"
       - "patches/*"
   workflow_dispatch:
+    inputs:
+      skip_release:
+        description: 'Skip release related steps? (true/false)'
+        required: true
+        default: 'false'
 
 env:
   version: m90-adbb69cd7f
-
-inputs:
-  skip_release:
-    description: 'Skip release related steps? (true/false)'
-    required: true
-    default: 'false'
 
 jobs:
 
@@ -24,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: python3 script/check_release.py --version ${{ env.version }}
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: python3 script/checkout.py --version ${{ env.version }}
@@ -35,7 +34,7 @@ jobs:
           name: Skia-${{ env.version }}-macos-Release-x64.zip
           path: '*.zip'
       - run: python3 script/release.py
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo ./script/prepare_linux.sh
       - run: python3 script/check_release.py --version ${{ env.version }}
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }}
@@ -56,7 +55,7 @@ jobs:
           name: Skia-${{ env.version }}-linux-Release-x64.zip
           path: '*.zip'
       - run: python3 script/release.py
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -68,7 +67,7 @@ jobs:
       - run: sudo ./script/prepare_linux.sh
       - run: sudo apt-get install binutils-2.26 -y
       - run: python3 script/check_release.py --version ${{ env.version }} --classifier gcc4
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }}
@@ -79,7 +78,7 @@ jobs:
           name: Skia-${{ env.version }}-linux-Release-x64-gcc4.zip
           path: '*.zip'
       - run: python3 script/release.py --classifier gcc4
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +94,7 @@ jobs:
           java-version: 1.8
       - run: sudo ./script/prepare_linux.sh
       - run: python3 script/check_release.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
@@ -106,7 +105,7 @@ jobs:
           name: Skia-${{ env.version }}-android-Release-${{ matrix.machine }}.zip
           path: '*.zip'
       - run: python3 script/release.py --system android --machine ${{ matrix.machine }}
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -116,7 +115,7 @@ jobs:
       - uses: actions/checkout@v2
       - shell: bash
         run: python3 script/check_release.py --version ${{ env.version }}
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: microsoft/setup-msbuild@v1
@@ -133,6 +132,6 @@ jobs:
           path: '*.zip'
       - shell: bash
         run: python3 script/release.py
-        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
+        if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        machine: [arm, arm64]
+        machine: [arm, arm64, x64, x86]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ on:
 env:
   version: m90-adbb69cd7f
 
+inputs:
+  skip_release:
+    description: 'Skip release related steps? (true/false)'
+    required: true
+    default: 'false'
+
 jobs:
 
   macos:
@@ -18,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: python3 script/check_release.py --version ${{ env.version }}
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: python3 script/checkout.py --version ${{ env.version }}
@@ -28,6 +35,7 @@ jobs:
           name: Skia-${{ env.version }}-macos-Release-x64.zip
           path: '*.zip'
       - run: python3 script/release.py
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -37,6 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo ./script/prepare_linux.sh
       - run: python3 script/check_release.py --version ${{ env.version }}
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }}
@@ -47,6 +56,7 @@ jobs:
           name: Skia-${{ env.version }}-linux-Release-x64.zip
           path: '*.zip'
       - run: python3 script/release.py
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,6 +68,7 @@ jobs:
       - run: sudo ./script/prepare_linux.sh
       - run: sudo apt-get install binutils-2.26 -y
       - run: python3 script/check_release.py --version ${{ env.version }} --classifier gcc4
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }}
@@ -68,6 +79,7 @@ jobs:
           name: Skia-${{ env.version }}-linux-Release-x64-gcc4.zip
           path: '*.zip'
       - run: python3 script/release.py --classifier gcc4
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,9 +93,9 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - run: ls -l /usr/local/lib/android/sdk/ndk-bundle
       - run: sudo ./script/prepare_linux.sh
       - run: python3 script/check_release.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 script/checkout.py --version ${{ env.version }} --system android --machine ${{ matrix.machine }}
@@ -94,6 +106,7 @@ jobs:
           name: Skia-${{ env.version }}-android-Release-${{ matrix.machine }}.zip
           path: '*.zip'
       - run: python3 script/release.py --system android --machine ${{ matrix.machine }}
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -103,6 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - shell: bash
         run: python3 script/check_release.py --version ${{ env.version }}
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: microsoft/setup-msbuild@v1
@@ -119,5 +133,6 @@ jobs:
           path: '*.zip'
       - shell: bash
         run: python3 script/release.py
+        if: ${{ INPUT_SKIP_RELEASE != 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/patches/SkParse.patch
+++ b/patches/SkParse.patch
@@ -6,7 +6,7 @@ index 4cbdaa5822..a71e7299a9 100644
      return str;
  }
  
-+#if !defined(SK_BUILD_FOR_ANDROID)
++#if !defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_ANDROID)
 +#include <locale.h>
 +#endif
 +

--- a/patches/SkParse.patch
+++ b/patches/SkParse.patch
@@ -2,13 +2,11 @@ diff --git a/src/utils/SkParse.cpp b/src/utils/SkParse.cpp
 index 4cbdaa5822..a71e7299a9 100644
 --- a/src/utils/SkParse.cpp
 +++ b/src/utils/SkParse.cpp
-@@ -199,12 +199,28 @@ const char* SkParse::FindMSec(const char str[], SkMSec* value)
+@@ -199,12 +199,26 @@ const char* SkParse::FindMSec(const char str[], SkMSec* value)
      return str;
  }
  
-+#if !defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_ANDROID)
 +#include <locale.h>
-+#endif
 +
 +#if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
 +#include <xlocale.h>

--- a/script/archive.py
+++ b/script/archive.py
@@ -15,11 +15,14 @@ def main():
   
   build_type = common.build_type()
   version = common.version()
+  machine = common.machine()
+  system = common.system()
+  classifier = common.classifier()
 
   globs = [
-    'out/' + build_type + '-' + common.machine + '/*.a',
-    'out/' + build_type + '-' + common.machine + '/*.lib',
-    'out/' + build_type + '-' + common.machine + '/icudtl.dat',
+    'out/' + build_type + '-' + machine + '/*.a',
+    'out/' + build_type + '-' + machine + '/*.lib',
+    'out/' + build_type + '-' + machine + '/icudtl.dat',
     'include/**/*',
     'modules/particles/include/*.h',
     'modules/skottie/include/*.h',
@@ -65,7 +68,7 @@ def main():
     "third_party/icu/*.h"
   ]
 
-  target = 'Skia-' + version + '-' + common.system + '-' + build_type + '-' + common.machine + common.classifier() + '.zip'
+  target = 'Skia-' + version + '-' + system + '-' + build_type + '-' + machine + classifier + '.zip'
   print('> Writing', target)
   
   with zipfile.ZipFile(os.path.join(os.pardir, target), 'w', compression=zipfile.ZIP_DEFLATED) as zip:

--- a/script/build.py
+++ b/script/build.py
@@ -6,6 +6,9 @@ def main():
   os.chdir(os.path.join(os.path.dirname(__file__), os.pardir, 'skia'))
 
   build_type = common.build_type()
+  machine = common.machine()
+  system = common.system()
+  ndk = common.ndk()  
 
   if build_type == 'Debug':
     args = ['is_debug=true']
@@ -13,7 +16,7 @@ def main():
     args = ['is_official_build=true']
 
   args += [
-    'target_cpu="' + common.machine + '"',
+    'target_cpu="' + machine + '"',
     'skia_use_system_expat=false',
     'skia_use_system_libjpeg_turbo=false',
     'skia_use_system_libpng=false',
@@ -32,35 +35,39 @@ def main():
     'skia_enable_skottie=true'
   ]
 
-  if 'macos' == common.system:
+  if 'macos' == system:
     args += [
       # 'skia_enable_gpu=true',
       # 'skia_use_gl=true',
       'skia_use_metal=true',
       'extra_cflags_cc=["-frtti"]'
     ]
-    if 'arm64' == common.machine:
+    if 'arm64' == machine:
       args += ['extra_cflags=["-stdlib=libc++"]']
     else:
       args += ['extra_cflags=["-stdlib=libc++", "-mmacosx-version-min=10.13"]']
-  elif 'linux' == common.system:
+  elif 'linux' == system:
     args += [
       # 'skia_enable_gpu=true',
       # 'skia_use_gl=true',
       'extra_cflags_cc=["-frtti"]',
       'cxx="g++-9"',
     ]
-  elif 'windows' == common.system:
+  elif 'windows' == system:
     args += [
       # 'skia_use_angle=true',
       'skia_use_direct3d=true',
       'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
     ]
+  elif 'android' == system:
+    args += [
+      'ndk="'+ ndk + '"'
+    ]
 
-  out = os.path.join('out', build_type + '-' + common.machine)
-  gn = 'gn.exe' if 'windows' == common.system else 'gn'
+  out = os.path.join('out', build_type + '-' + machine)
+  gn = 'gn.exe' if 'windows' == system else 'gn'
   subprocess.check_call([os.path.join('bin', gn), 'gen', out, '--args=' + ' '.join(args)])
-  ninja = 'ninja.exe' if 'windows' == common.system else 'ninja'
+  ninja = 'ninja.exe' if 'windows' == system else 'ninja'
   subprocess.check_call([os.path.join('..', 'depot_tools', ninja), '-C', out, 'skia', 'modules'])
 
   return 0

--- a/script/check_release.py
+++ b/script/check_release.py
@@ -6,11 +6,14 @@ def main():
   headers = common.github_headers()
   version = common.version()
   build_type = common.build_type()
+  system = common.system()
+  machine = common.machine()
+  classifier = common.classifier()
   
   try:
     resp = urllib.request.urlopen(urllib.request.Request('https://api.github.com/repos/JetBrains/skia-build/releases/tags/' + version, headers=headers)).read()
     artifacts = [x['name'] for x in json.loads(resp.decode('utf-8'))['assets']]
-    zip = 'Skia-' + version + '-' + common.system + '-' + build_type + '-' + common.machine + common.classifier() + '.zip'
+    zip = 'Skia-' + version + '-' + system + '-' + build_type + '-' + machine + classifier + '.zip'
     if zip in artifacts:
       print('> Artifact "' + zip + '" exists, stopping')
       return 1

--- a/script/checkout.py
+++ b/script/checkout.py
@@ -5,8 +5,7 @@ import argparse, common, os, pathlib, platform, re, subprocess, sys
 def main():
   os.chdir(os.path.join(os.path.dirname(__file__), os.pardir))
   
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--version', required=True)
+  parser = common.create_parser(True)
   args = parser.parse_args()
 
   # Clone depot_tools
@@ -47,7 +46,7 @@ def main():
     subprocess.check_call(["git", "apply", str(x)])
 
   # git deps
-  if 'windows' == common.system:
+  if 'windows' == common.system():
     env = os.environ.copy()
     env['PYTHONHTTPSVERIFY']='0'
     subprocess.check_call(["python", "tools/git-sync-deps"], env=env)

--- a/script/common.py
+++ b/script/common.py
@@ -2,14 +2,28 @@
 
 import argparse, base64, os, platform, re, subprocess
 
-system = {'Darwin': 'macos', 'Linux': 'linux', 'Windows': 'windows'}[platform.system()]
-machine = {'AMD64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64'}[platform.machine()]
-
-def version():
+def create_parser(version_required=False):
   parser = argparse.ArgumentParser()
   parser.add_argument('--debug', action='store_true')
-  parser.add_argument('--version')
+  parser.add_argument('--version', required=version_required)
   parser.add_argument('--classifier')
+  parser.add_argument('--system')
+  parser.add_argument('--machine')
+  parser.add_argument('--ndk')
+  return parser
+
+def system():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.system if args.system else {'Darwin': 'macos', 'Linux': 'linux', 'Windows': 'windows'}[platform.system()]
+
+def machine():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.machine if args.machine else {'AMD64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64'}[platform.machine()]
+
+def version():
+  parser = create_parser()
   args = parser.parse_args()
   
   if args.version:
@@ -22,18 +36,12 @@ def version():
   return version + '-' + revision.strip()[:10]
 
 def build_type():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--debug', action='store_true')
-  parser.add_argument('--version')
-  parser.add_argument('--classifier')
+  parser = create_parser()
   (args, _) = parser.parse_known_args()
   return 'Debug' if args.debug else 'Release'
 
 def classifier():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--debug', action='store_true')
-  parser.add_argument('--version')
-  parser.add_argument('--classifier')
+  parser = create_parser()
   (args, _) = parser.parse_known_args()
   return '-' + args.classifier if args.classifier else ''
   
@@ -46,3 +54,9 @@ def github_headers():
     'Accept': 'application/vnd.github.v3+json',
     'Authorization': auth
   }
+
+def ndk():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.ndk if args.ndk else ''
+

--- a/script/release.py
+++ b/script/release.py
@@ -6,9 +6,12 @@ def main():
   os.chdir(os.path.join(os.path.dirname(__file__), os.pardir, 'skia'))
   version = common.version()
   build_type = common.build_type()
+  machine = common.machine()
+  system = common.system()
+  classifier = common.classifier()
   os.chdir(os.pardir)
 
-  zip = 'Skia-' + version + '-' + common.system + '-' + build_type + '-' + common.machine + common.classifier() + '.zip'
+  zip = 'Skia-' + version + '-' + system + '-' + build_type + '-' + machine + classifier + '.zip'
   if not os.path.exists(zip):
     print('Can\'t find "' + zip + '"')
     return 1


### PR DESCRIPTION
In preparation for having a Skija on Android (https://github.com/JetBrains/skija/issues/101) this PR adds Android builds to the toolchain. This PR includes:

- [x] An Android build matrix to compile Skia with NDK
- [x] Unifying a bit the argument parsing of the python scripts 
- [x] A new input for GitHub Actions to Skip any release related steps (allows better building in forks and trying out things without actually publishing a release)

I couldn't check the binaries yet so I trust that the Skia script handles the compilation well. Next step will be to extend Skija to target Android. 

See latest compilation here: 
https://github.com/Danielku15/skia-build/actions/runs/680600460 
